### PR TITLE
fix: restrict download to v2.4.* releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Automatic installation for TorrentPier
+## Automatic installation for TorrentPier v2.4.*
 **This shell script allows you to:**
-- Install TorrentPier in automatic mode;
+- Install TorrentPier v2.4.* in automatic mode;
 ## Supported systems:
 - **GNU/Linux:** Debian 12
 - **GNU/Linux:** Ubuntu 22.04, 24.04

--- a/deb.install.sh
+++ b/deb.install.sh
@@ -218,7 +218,7 @@ EOF
         sudo mkdir -p /tmp/torrentpier 2>&1 | sudo tee -a "$logsInst" > /dev/null
 
         # Downloading TorrentPier
-        curl -s https://api.github.com/repos/torrentpier/torrentpier/releases | jq -r 'map(select(.prerelease == false)) | .[0].zipball_url' | xargs -n 1 curl -L -o /tmp/torrentpier/torrentpier.zip 2>&1 | sudo tee -a "$logsInst" > /dev/null
+        curl -s https://api.github.com/repos/torrentpier/torrentpier/releases | jq -r 'map(select(.prerelease == false and (.tag_name | test("^v2\\.4\\.")))) | .[0].zipball_url' | xargs -n 1 curl -L -o /tmp/torrentpier/torrentpier.zip 2>&1 | sudo tee -a "$logsInst" > /dev/null
         sudo unzip -o /tmp/torrentpier/torrentpier.zip -d /tmp/torrentpier 2>&1 | sudo tee -a "$logsInst" > /dev/null
         sudo mv /tmp/torrentpier/torrentpier-torrentpier-* /var/www/torrentpier 2>&1 | sudo tee -a "$logsInst" > /dev/null
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to specify that the installation script is intended for TorrentPier v2.4.*.

* **Bug Fixes**
  * Modified the installation script to only download and install stable TorrentPier releases from the 2.4.x series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->