### PR TITLE
feat: Added SSL certificate generation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,26 @@ chmod +x ./autoinstall/install.sh
 ```
 **Run automatic installation**
 ```bash
-# Default installation (NGINX, v2.4)
+# Default installation (NGINX, v2.4, SSL auto)
 ./autoinstall/install.sh
 
 # With custom options
 ./autoinstall/install.sh --webserver nginx --version v2.4
 ./autoinstall/install.sh --webserver apache --version v2.8
 ./autoinstall/install.sh --webserver caddy --version v2.4
+
+# With SSL and email (for domain)
+./autoinstall/install.sh --webserver nginx --version v2.4 --email admin@example.com
+
+# Disable SSL (use HTTP only)
+./autoinstall/install.sh --webserver nginx --ssl no
 ```
 
 **Available options:**
 - `--webserver <nginx|apache|caddy>` - Choose web server (default: nginx)
 - `--version <v2.4|v2.8>` - Choose TorrentPier version (default: v2.4)
+- `--ssl <auto|yes|no>` - Enable SSL/TLS (default: auto - enabled for domains only)
+- `--email <email@example.com>` - Email for SSL certificate (required if domain is used)
 - `--help` - Show help message
 
 > [!NOTE]
@@ -52,6 +60,9 @@ chmod +x ./autoinstall/deb.install.sh && ./autoinstall/deb.install.sh --webserve
 ## Additional information:
 - **Web server:** NGINX/Apache/Caddy + PHP 8.4-FPM (configurable)
 - **PHP version:** 8.4 (latest from Ondřej Surý's repository)
+- **SSL/TLS:** Automatic Let's Encrypt certificates (for domains)
+  - **Caddy:** Built-in automatic HTTPS
+  - **NGINX/Apache:** Certbot with auto-renewal
 - **Cron schedule:** Every 10 minutes
 - **Installation logs directory:** /var/log/torrentpier_install.log
 - **Temporary directory:** /tmp/torrentpier

--- a/USAGE_EXAMPLES.md
+++ b/USAGE_EXAMPLES.md
@@ -24,6 +24,33 @@
 ./autoinstall/install.sh --webserver nginx --version v2.8
 ```
 
+## SSL/HTTPS Configurations
+
+### Automatic SSL for domain (recommended)
+```bash
+# SSL will be automatically configured when you enter a domain
+./autoinstall/install.sh --webserver nginx --email admin@example.com
+```
+
+### Caddy with automatic HTTPS
+```bash
+# Caddy automatically obtains and renews SSL certificates
+./autoinstall/install.sh --webserver caddy --email admin@example.com
+```
+
+### Disable SSL (HTTP only)
+```bash
+# Use this for local development or if you have external SSL termination
+./autoinstall/install.sh --webserver nginx --ssl no
+```
+
+### Force SSL even for IP (not recommended)
+```bash
+# This will fail, as Let's Encrypt requires a domain
+./autoinstall/install.sh --webserver nginx --ssl yes
+# Note: If you enter an IP, SSL will be automatically disabled with a warning
+```
+
 ## Direct Installation (Skip Download)
 
 If you've already cloned the repository:
@@ -49,6 +76,8 @@ Usage: ./autoinstall/deb.install.sh [OPTIONS]
 Options:
   --webserver <nginx|apache|caddy>  Choose web server (default: nginx)
   --version <v2.4|v2.8>              Choose TorrentPier version (default: v2.4)
+  --ssl <auto|yes|no>                Enable SSL/TLS (default: auto - only for domains)
+  --email <email@example.com>        Email for SSL certificate (required if domain is used)
   --help                             Show this help message
 ```
 
@@ -57,14 +86,20 @@ Options:
 ### Changes in this version:
 1. **Web Server Selection** - Choose between NGINX, Apache, or Caddy
 2. **Version Selection** - Install either v2.4.x or v2.8.x of TorrentPier
-3. **Cron Interval** - Changed from 1 minute to 10 minutes for better performance
-4. **PHP 8.4** - Automatic installation of PHP 8.4 from Ondřej Surý's repository
+3. **Automatic SSL/HTTPS** - Let's Encrypt certificates with auto-renewal
+   - **Caddy:** Built-in automatic HTTPS (zero configuration)
+   - **NGINX/Apache:** Certbot with automatic renewal via cron
+   - **Smart Detection:** SSL auto-enabled for domains, disabled for IPs
+4. **Cron Interval** - Changed from 1 minute to 10 minutes for better performance
+5. **PHP 8.4** - Automatic installation of PHP 8.4 from Ondřej Surý's repository
 
 ### Default Values:
 - Web Server: `nginx`
 - TorrentPier Version: `v2.4`
 - PHP Version: `8.4` (automatically installed)
+- SSL: `auto` (enabled for domains, disabled for IPs)
 - Cron Schedule: `*/10 * * * *` (every 10 minutes)
+- SSL Auto-Renewal: Daily check at 3 AM (NGINX/Apache) or automatic (Caddy)
 
 ## Post-Installation
 
@@ -74,8 +109,25 @@ After installation, you'll find credentials in:
 ```
 
 ### Access Points:
-- **TorrentPier:** `http://YOUR_HOST/`
-- **phpMyAdmin:** `http://YOUR_HOST:9090/phpmyadmin`
+- **TorrentPier:** `https://YOUR_DOMAIN/` (or `http://YOUR_IP/` for IP-based installs)
+- **phpMyAdmin:** `https://YOUR_DOMAIN:9090/phpmyadmin`
+
+> **Note:** If you used a domain, the script automatically configures HTTPS. First access may take a few seconds while certificates are obtained (especially with Caddy).
+
+### SSL Certificate Information:
+- **Location (NGINX/Apache):** `/etc/letsencrypt/live/YOUR_DOMAIN/`
+- **Auto-renewal:** Certificates renew automatically 30 days before expiration
+- **Manual renewal (if needed):**
+  ```bash
+  # For NGINX
+  certbot renew --nginx
+  
+  # For Apache
+  certbot renew --apache
+  
+  # For Caddy (automatic, but can force)
+  caddy reload --config /etc/caddy/Caddyfile
+  ```
 
 ### Log File:
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installer now supports SSL/TLS with new options: --ssl (auto|yes|no) and --email.
  * Automatic HTTPS for domain-based installs; falls back to HTTP for IPs.
  * Integrated certificate issuance and auto-renewal (including scheduled renewals); Caddy auto-TLS supported.
  * Post-install URLs use https when enabled, with clear status and renewal details.

* **Documentation**
  * Expanded guidance on SSL/HTTPS setup, options, and workflows.
  * Added examples for enabling/disabling SSL, server-specific notes (NGINX/Apache/Caddy), and renewal instructions.
  * Updated defaults and access instructions reflecting HTTPS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->