### PR TITLE
fix(install): add OS version check and fix Debian PHP repository error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 - Choose web server (NGINX, Apache, or Caddy);
 - Flexible configuration with command-line arguments;
 ## Supported systems:
-- **GNU/Linux:** Debian 12
-- **GNU/Linux:** Ubuntu 22.04, 24.04
+- **GNU/Linux:** Debian 12 and newer
+- **GNU/Linux:** Ubuntu 22.04, 24.04 and newer
 > [!IMPORTANT]
 > The architecture and bit depth of x86_64 are required.
+> 
+> Minimum supported versions: **Debian 12** and **Ubuntu 22.04**
 ## Starting the auto installer:
 **Update indexes and packages**
 ```bash


### PR DESCRIPTION
- Add minimum OS version validation (Ubuntu 22.04+, Debian 12+)
- Fix PPA installation error on Debian by using direct sury.org repository
- Ubuntu: continues using PPA via add-apt-repository
- Debian: uses direct repository from packages.sury.org with GPG key
- Update documentation with minimum version requirements
- Remove version check from install.sh wrapper (kept only in deb.install.sh)

The PPA method (add-apt-repository ppa:ondrej/php) only works on Ubuntu and causes installation failures on Debian. Now each OS uses its own appropriate method for adding the Ondřej Surý PHP repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installer now validates OS versions and exits on unsupported systems (Ubuntu 22.04+ and Debian 12+).
  * OS-aware PHP repository setup: Ubuntu via PPA; Debian via packages.sury.org with automatic key handling.
  * Clearer success/error messages during checks and setup.

* **Documentation**
  * Updated README to generalize supported OS wording and explicitly list minimum supported versions (Debian 12, Ubuntu 22.04+), with minor formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->